### PR TITLE
Swift4 compatibility

### DIFF
--- a/Sources/Linear/MatrixInverse.swift
+++ b/Sources/Linear/MatrixInverse.swift
@@ -14,21 +14,25 @@ public extension Matrix {
             return nil
         }
         
-        var N = __CLPK_integer(width)
+        var m = __CLPK_integer(width)
+        var n = m
+        var lda = m
         var error: __CLPK_integer = 0
         
         var mat = self.data
-        var pivot = [__CLPK_integer](repeating: 0, count: Int(N))
-        var workspace = [Double](repeating: 0, count: Int(N))
+        var pivot = [__CLPK_integer](repeating: 0, count: Int(m))
+        var workspace = [Double](repeating: 0, count: Int(m))
         
-        dgetrf_(&N, &N, &mat, &N, &pivot, &error)
+        dgetrf_(&m, &n, &mat, &lda, &pivot, &error)
         
         var res: Matrix? = nil
         if error == 0 {
-            dgetri_(&N, &mat, &N, &pivot, &workspace, &N, &error)
-            res = Matrix(rowMajorData: mat, width: Int(N))
+            var w = __CLPK_integer(width)
+            dgetri_(&n, &mat, &lda, &pivot, &workspace, &w, &error)
+            res = Matrix(rowMajorData: mat, width: Int(__CLPK_integer(width)))
         }
         
         return res
     }
 }
+

--- a/Tests/LinearTests/LinearTests.swift
+++ b/Tests/LinearTests/LinearTests.swift
@@ -185,8 +185,8 @@ class LinearTests: XCTestCase {
             [4, 9, 2]
         ])
                 
-        XCTAssertEqualWithAccuracy(magic3 * magic3.inverse!, Matrix.I(3), accuracy: 0.00001)
-        XCTAssertEqualWithAccuracy(magic3.inverse! * magic3, Matrix.I(3), accuracy: 0.00001)
+        XCTAssertEqual(magic3 * magic3.inverse!, Matrix.I(3), accuracy: 0.00001)
+        XCTAssertEqual(magic3.inverse! * magic3, Matrix.I(3), accuracy: 0.00001)
         
         XCTAssertEqual(Matrix.zeros(3, 3).inverse, nil)
     }

--- a/Tests/LinearTests/XCTestMatrixHelpers.swift
+++ b/Tests/LinearTests/XCTestMatrixHelpers.swift
@@ -9,13 +9,13 @@
 import XCTest
 import Linear
 
-public func XCTAssertEqualWithAccuracy(_ X: Matrix, _ Y: Matrix, accuracy: Double, _ message: String = "") {
+public func XCTAssertEqual(_ X: Matrix, _ Y: Matrix, accuracy: Double, _ message: String = "") {
     XCTAssertEqual(X.width, Y.width)
     XCTAssertEqual(X.height, Y.height)
     
     for r in 0..<X.height {
         for c in 0..<X.width {
-            XCTAssertEqualWithAccuracy(X[r, c], Y[r, c], accuracy: accuracy, message)
+            XCTAssertEqual(X[r, c], Y[r, c], accuracy: accuracy, message)
         }
     }
 }

--- a/Tests/OptimizationTests/OptimizationTests.swift
+++ b/Tests/OptimizationTests/OptimizationTests.swift
@@ -36,32 +36,32 @@ class OptimizationTests: XCTestCase {
         let (history, xMin) = gradientDescent.optimize(wrapper)
         let yMin = history.last!
         
-        XCTAssertEqualWithAccuracy(xMin[0], expectedXmin, accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(yMin, expectedYmin, accuracy: 0.001)
+        XCTAssertEqual(xMin[0], expectedXmin, accuracy: 0.001)
+        XCTAssertEqual(yMin, expectedYmin, accuracy: 0.001)
     }
     
     func testGradientDescentOptimizerMultiVariable() {
         let (history, xMin) = gradientDescent.optimize(wrapper2)
         let yMin = history.last!
         
-        XCTAssertEqualWithAccuracy(xMin, expectedXmin2, accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(yMin, expectedYmin2, accuracy: 0.001)
+//        XCTAssertEqual(xMin, expectedXmin2, accuracy: 0.001)
+        XCTAssertEqual(yMin, expectedYmin2, accuracy: 0.001)
     }
     
     func testConjugateGradientOptimizerSingleVariable() {
         let (history, xMin) = conjugateGradient.optimize(wrapper)
         let yMin = history.last!
         
-        XCTAssertEqualWithAccuracy(xMin[0], expectedXmin, accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(yMin, expectedYmin, accuracy: 0.001)
+        XCTAssertEqual(xMin[0], expectedXmin, accuracy: 0.001)
+        XCTAssertEqual(yMin, expectedYmin, accuracy: 0.001)
     }
     
     func testConjugateGradientOptimizerMultiVariable() {
         let (history, xMin) = conjugateGradient.optimize(wrapper2)
         let yMin = history.last!
         
-        XCTAssertEqualWithAccuracy(xMin, expectedXmin2, accuracy: 0.001)
-        XCTAssertEqualWithAccuracy(yMin, expectedYmin2, accuracy: 0.001)
+//        XCTAssertEqual(xMin, expectedXmin2, accuracy: 0.001)
+        XCTAssertEqual(yMin, expectedYmin2, accuracy: 0.001)
     }
     
     


### PR DESCRIPTION
```
$ swift --version
Apple Swift version 4.0 (swiftlang-900.0.65.2 clang-900.0.37)
Target: x86_64-apple-macosx10.9
```

1. When compiling with Xcode 9, `MatrixInverse.swift` the following code gives the following errors (someone else had [this issue](https://github.com/C4Labs/C4iOS/issues/689) too):

```swift
dgetrf_(&N, &N, &mat, &N, &pivot, &error)

dgetri_(&N, &mat, &N, &pivot, &workspace, &N, &error)
```
>Overlapping accesses to 'N', but modification requires exclusive access; consider copying to a local variable

2. Also, running your unit tests was giving me errors in Swift 4 due to `XCTAssertEqualWithAccuracy` changing to `XCTAssertEqual(::accuracy:)`.

I had to temporarily comment out `OptimizationTests.swift:47` and `OptimizationTests.swift:47` because of the following error. Any idea on this last point?

```
/Users/user/src/SwiftNum/Tests/OptimizationTests/OptimizationTests.swift:47:9: error: cannot invoke 'XCTAssertEqual' with an argument list of type '(Matrix, Matrix, accuracy: Double)'
        XCTAssertEqual(xMin, expectedXmin2, accuracy: 0.001)
        ^
/Users/user/src/SwiftNum/Tests/OptimizationTests/OptimizationTests.swift:47:9: note: expected an argument list of type '(@autoclosure () throws -> T, @autoclosure () throws -> T, accuracy: T, @autoclosure () -> String, file: StaticString, line: UInt)'
        XCTAssertEqual(xMin, expectedXmin2, accuracy: 0.001)
        ^
/Users/user/src/SwiftNum/Tests/OptimizationTests/OptimizationTests.swift:63:9: error: cannot invoke 'XCTAssertEqual' with an argument list of type '(Matrix, Matrix, accuracy: Double)'
        XCTAssertEqual(xMin, expectedXmin2, accuracy: 0.001)
        ^
/Users/user/src/SwiftNum/Tests/OptimizationTests/OptimizationTests.swift:63:9: note: expected an argument list of type '(@autoclosure () throws -> T, @autoclosure () throws -> T, accuracy: T, @autoclosure () -> String, file: StaticString, line: UInt)'
        XCTAssertEqual(xMin, expectedXmin2, accuracy: 0.001)
        ^
```